### PR TITLE
/esami reworked

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -71,8 +71,8 @@ def lezioni(update: Update, context: CallbackContext, *m):
 def get_esami_text_InlineKeyboard(context: CallbackContext) -> (str, InlineKeyboardMarkup): #restituisce una tuple formata da (message_text, InlineKeyboardMarkup)
     keyboard = [[]]
 
-    text_anno = ", ".join([key for key, value in context.user_data.items() if context.user_data.get(key, False) and "anno" in key]) #stringa contenente gli anni per cui la flag è true
-    text_sessione = ", ".join([key for key, value in context.user_data.items() if context.user_data.get(key, False) and "sessione" in key]).replace("sessione", "") #stringa contenente le sessioni per cui la flag è true
+    text_anno = ", ".join([key for key, value in context.user_data.items() if value and "anno" in key]) #stringa contenente gli anni per cui la flag è true
+    text_sessione = ", ".join([key for key, value in context.user_data.items() if value and "sessione" in key]).replace("sessione", "") #stringa contenente le sessioni per cui la flag è true
     text_insegnamento = context.user_data.get("insegnamento", "") #stringa contenente l'insegnamento
 
     message_text = "Anno: {}\nSessione: {}\nInsegnamento: {}"\
@@ -106,7 +106,7 @@ def esami(update: Update, context: CallbackContext):
 def esami_input_insegnamento(update: Update, context: CallbackContext):
     if context.user_data.get('cmd', 'null') == "input_insegnamento": #se effettivamente l'user aveva richiesto di modificare l'insegnamento...
         check_log(update, context, "esami_input_insegnamento")
-        context.user_data['insegnamento'] = re.sub(r"^(?!=<[/])ins:\s+", "", update.message.text) #ottieni il nome dell'insegnamento e salvalo nel dict
+        context.user_data['insegnamento'] = re.sub(r"^(?!=<[/])[Ii]ns:\s+", "", update.message.text) #ottieni il nome dell'insegnamento e salvalo nel dict
         del context.user_data['cmd'] #elimina la possibilità di modificare l'insegnamento fino a quando l'apposito button non viene premuto di nuovo
         reply = get_esami_text_InlineKeyboard(context)
         context.bot.sendMessage(chat_id=update.message.chat_id, text=reply[0], reply_markup=reply[1])

--- a/functions.py
+++ b/functions.py
@@ -108,7 +108,7 @@ def help_cmd():
 
 
 def informative_callback(update: Update, context: CallbackContext):
-    cmd = update.message.text.split(' ')[0][1:] #prende solo la prima parola (cioè il comando) ed esclude lo slash
+    cmd = update.message.text.split(' ')[0][1:] #prende solo la prima parola del messaggio (cioè il comando) escludendo lo slash
     check_log(update, context, cmd)
     message_text = read_md(cmd)
     context.bot.sendMessage(chat_id=update.message.chat_id, text=message_text, parse_mode='Markdown')
@@ -526,7 +526,6 @@ def send_errors(update: Update, context: CallbackContext):
         context.bot.sendDocument(chat_id=config_map['dev_group_chatid'], document=open('logs/errors.txt', 'rb'))
 
 def updater_lep(context):
-    job = context.job
     year_exam = get_year_code(11 , 30) # aaaa/12/01 (cambio nuovo anno esami) data dal quale esami del vecchio a nuovo anno coesistono
     scrape_exams("1" + str(year_exam), delete= True) # flag che permette di eliminare tutti gli esami presenti in tabella exams
     if(check_print_old_exams(year_exam)):

--- a/main.py
+++ b/main.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from functions import *
+from functions import TOKEN, Bot, Updater, MessageHandler, CommandHandler, CallbackQueryHandler, Filters, telegram, Update, CallbackContext,\
+	smonta_portoni, santino, prof_sticker, bladrim, lei_che_ne_pensa_signorina, informative_callback, lezioni, esami, prof, report, give_chat_id, send_log, send_chat_ids, send_errors, start, callback, help,\
+	regolamenti, regolamentodidattico, regolamentodidattico_button, regolamentodidattico_keyboard, triennale, magistrale, regdid,\
+	generic_button_handler, gitlab_handler, submenu_handler, md_handler,\
+	updater_lep, git, drive, stats, stats_tot, request, add_db #importati solo componenti utilizzati nel main
 from module.shared import config_map
 
 bot = telegram.Bot(config_map["token"])
@@ -58,7 +62,7 @@ def main():
 	dp.add_handler(CommandHandler('prof', prof))
 
 	dp.add_handler(CommandHandler('aulario', informative_callback))
-	dp.add_handler(CommandHandler('help',help))
+	dp.add_handler(CommandHandler('help', help))
 	dp.add_handler(CommandHandler('contributors', informative_callback))
 
 	dp.add_handler(CommandHandler('rappresentanti', informative_callback))
@@ -74,7 +78,7 @@ def main():
 	dp.add_handler(CommandHandler('cloud', informative_callback))
 
   # generic buttons
-	dp.add_handler(CallbackQueryHandler(generic_button_handler, pattern='^(esami_buttonlezioni_button|help_cmd|exit_cmd)'))
+	dp.add_handler(CallbackQueryHandler(generic_button_handler, pattern='^(esami_button|lezioni_button|help_cmd|exit_cmd)'))
 	dp.add_handler(CallbackQueryHandler(submenu_handler,        pattern='sm_*'))
 	dp.add_handler(CallbackQueryHandler(md_handler,             pattern='md_*'))
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from functions import TOKEN, Bot, Updater, MessageHandler, CommandHandler, CallbackQueryHandler, Filters, telegram, Update, CallbackContext,\
 	smonta_portoni, santino, prof_sticker, bladrim, lei_che_ne_pensa_signorina, informative_callback, lezioni, esami, prof, report, give_chat_id, send_log, send_chat_ids, send_errors, start, callback, help,\
-	regolamenti, regolamentodidattico, regolamentodidattico_button, regolamentodidattico_keyboard, triennale, magistrale, regdid,\
+	regolamenti, regolamentodidattico, regolamentodidattico_button, regolamentodidattico_keyboard, triennale, magistrale, regdid, esami_handler, esami_input_insegnamento,\
 	generic_button_handler, gitlab_handler, submenu_handler, md_handler,\
 	updater_lep, git, drive, stats, stats_tot, request, add_db #importati solo componenti utilizzati nel main
 from module.shared import config_map
@@ -78,7 +78,7 @@ def main():
 	dp.add_handler(CommandHandler('cloud', informative_callback))
 
   # generic buttons
-	dp.add_handler(CallbackQueryHandler(generic_button_handler, pattern='^(esami_button|lezioni_button|help_cmd|exit_cmd)'))
+	dp.add_handler(CallbackQueryHandler(generic_button_handler, pattern='^(lezioni_button|help_cmd|exit_cmd)'))
 	dp.add_handler(CallbackQueryHandler(submenu_handler,        pattern='sm_*'))
 	dp.add_handler(CallbackQueryHandler(md_handler,             pattern='md_*'))
 
@@ -93,6 +93,10 @@ def main():
 	dp.add_handler(CallbackQueryHandler(regdid,                      pattern='regdid_button'))
 	dp.add_handler(CallbackQueryHandler(regolamenti,                 pattern='Regolamento*'))
 	dp.add_handler(CallbackQueryHandler(regolamentodidattico_button, pattern='regolamentodidattico_button'))
+
+	#esami
+	dp.add_handler(MessageHandler(Filters.regex(r"^(?!=<[/])ins:\s+"), esami_input_insegnamento))
+	dp.add_handler(CallbackQueryHandler(esami_handler, pattern='esami_button_*'))
 
 	#JobQueue
 	j = updater.job_queue

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def main():
 	dp.add_handler(CallbackQueryHandler(regolamentodidattico_button, pattern='regolamentodidattico_button'))
 
 	#esami
-	dp.add_handler(MessageHandler(Filters.regex(r"^(?!=<[/])ins:\s+"), esami_input_insegnamento))
+	dp.add_handler(MessageHandler(Filters.regex(r"^(?!=<[/])[Ii]ns:\s+"), esami_input_insegnamento)) #regex accetta [/ins: nome] oppure [/Ins: nome], per agevolare chi usa il cellulare
 	dp.add_handler(CallbackQueryHandler(esami_handler, pattern='esami_button_*'))
 
 	#JobQueue

--- a/module/esami.py
+++ b/module/esami.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import re
 
 def esami_output(item, sessions):
 
@@ -9,15 +10,15 @@ def esami_output(item, sessions):
 	output += "\n*Docenti:* " + item["docenti"]
 
 	for session in sessions:
-		appeal = item[session]
-		if appeal:
-			appeal = str(appeal)
-			appeal = appeal.replace("[", "")
-			appeal = appeal.replace("]", "")
-			appeal = appeal.replace("'", "")
-			appeal = appeal.split("', '")
-			if "".join(appeal) != "":
-				output += "\n*" + session.title() + ":* " + " | ".join(appeal)
+		appeals = item[session]
+		if appeals:
+			appeals = str(appeals)			
+			appeals = re.sub(r"(?P<ora>([01]?\d|2[0-3]):[0-5][0-9])(?P<parola>\w)", r"\g<ora> - \g<parola>", appeals) #aggiunge un - per separare orario e luogo dell'esame
+			appeals = appeals.split("', '") #separa i vari appelli della sessione
+			for i, appeal in enumerate(appeals):
+				appeals[i] = re.sub(r"[\['\]]", "", appeal) #elimina eventuali caratteri [ ' ] rimasti
+			if "".join(appeals) != "":
+				output += "\n*" + session.title() + ":*\n" + "\n".join(appeals)
 
 	output += "\n*CDL:* " + item["cdl"]
 	output += "\n*Anno:* " + item["anno"] + "\n"

--- a/module/esami.py
+++ b/module/esami.py
@@ -44,22 +44,19 @@ def dict_factory(cursor, row):
 
 def esami_cmd(userDict):
 	output_str = []
- 	#stringa contenente le sessioni per cui la flag è true, separate da ", " 	
-	select_sessione = ", ".join([key for key, value in userDict.items() if value and "sessione" in key]).replace("sessione", "") #risultat es.=> , prima, seconda, terza
-	#stringa contenente le sessioni per cui la flag è true, separate da " = '[]' and not " 		
-	where_sessione = " = '[]' and not ".join([key for key, value in userDict.items() if value and "sessione" in key]).replace("sessione", "") #risultat es=> and not prima = '[] and not terza = '[]' 
-	#stringa contenente gli anni per cui la flag è true, separate da "' or anno = '"	
-	where_anno = "' or anno = '".join([key for key, value in userDict.items() if value and "anno" in key]) #riustato es.=>  and (anno = '1° anno' or anno = '3° anno)'
-	#stringa contenente l'insegnamento, se presente		
-	where_insegnamento = userDict.get("insegnamento", "") #=> and insegnamento LIKE '%stringa%'
+ 	
+	select_sessione = ", ".join([key for key in userDict.keys() if "sessione" in key]).replace("sessione", "") #stringa contenente le sessioni per cui il dict contiene la key, separate da ", " 	
+	where_sessione = " = '[]' and not ".join([key for key in userDict.keys() if "sessione" in key]).replace("sessione", "") #stringa contenente le sessioni per cui il dict contiene la key, separate da " = '[]' and not " 
+	where_anno = "' or anno = '".join([key for key in userDict.keys() if "anno" in key]) #stringa contenente gli anni per cui il dict contiene la key, separate da "' or anno = '"	
+	where_insegnamento = userDict.get("insegnamento", "")  #stringa contenente l'insegnamento, se presente
 
 	query = """SELECT anno, cdl, docenti, insegnamento{} 
 			   FROM exams
 			   WHERE true {} {} {}""".format(
-	", " + select_sessione if select_sessione else ", prima, seconda, terza, straordinaria",
-	"and not " + where_sessione + " = '[]'" if where_sessione else "",
-	"and (anno = '" + where_anno + "')" if where_anno else "",
-	"and insegnamento LIKE '%" + where_insegnamento + "%'" if where_insegnamento else ""
+	", " + select_sessione if select_sessione else ", prima, seconda, terza, straordinaria", #es.=> , prima, seconda, terza
+	"and not " + where_sessione + " = '[]'" if where_sessione else "", #es.=> and not prima = '[] and not terza = '[]' 
+	"and (anno = '" + where_anno + "')" if where_anno else "", #es.=>  and (anno = '1° anno' or anno = '3° anno)'
+	"and insegnamento LIKE '%" + where_insegnamento + "%'" if where_insegnamento else "" #es.=> and insegnamento LIKE '%stringa%'
 	)
 
 	conn = sqlite3.connect('data/DMI_DB.db')

--- a/module/esami.py
+++ b/module/esami.py
@@ -45,11 +45,11 @@ def dict_factory(cursor, row):
 def esami_cmd(userDict):
 	output_str = []
  	#stringa contenente le sessioni per cui la flag è true, separate da ", " 	
-	select_sessione = ", ".join([key for key, value in userDict.items() if userDict.get(key, False) and "sessione" in key]).replace("sessione", "") #=> , prima, seconda, terza
+	select_sessione = ", ".join([key for key, value in userDict.items() if value and "sessione" in key]).replace("sessione", "") #risultat es.=> , prima, seconda, terza
 	#stringa contenente le sessioni per cui la flag è true, separate da " = '[]' and not " 		
-	where_sessione = " = '[]' and not ".join([key for key, value in userDict.items() if userDict.get(key, False) and "sessione" in key]).replace("sessione", "") #=> and not prima = '[] and not terza = '[]' 
-	#stringa contenente gli anni per cui la flag è true, separate da "' and anno = '"	
-	where_anno = "' and anno = '".join([key for key, value in userDict.items() if userDict.get(key, False) and "anno" in key]) #=>  and anno = '1° anno' and anno = '3° anno'
+	where_sessione = " = '[]' and not ".join([key for key, value in userDict.items() if value and "sessione" in key]).replace("sessione", "") #risultat es=> and not prima = '[] and not terza = '[]' 
+	#stringa contenente gli anni per cui la flag è true, separate da "' or anno = '"	
+	where_anno = "' or anno = '".join([key for key, value in userDict.items() if value and "anno" in key]) #riustato es.=>  and (anno = '1° anno' or anno = '3° anno)'
 	#stringa contenente l'insegnamento, se presente		
 	where_insegnamento = userDict.get("insegnamento", "") #=> and insegnamento LIKE '%stringa%'
 
@@ -58,7 +58,7 @@ def esami_cmd(userDict):
 			   WHERE true {} {} {}""".format(
 	", " + select_sessione if select_sessione else ", prima, seconda, terza, straordinaria",
 	"and not " + where_sessione + " = '[]'" if where_sessione else "",
-	"and anno = '" + where_anno + "'" if where_anno else "",
+	"and (anno = '" + where_anno + "')" if where_anno else "",
 	"and insegnamento LIKE '%" + where_insegnamento + "%'" if where_insegnamento else ""
 	)
 


### PR DESCRIPTION
**Primo commit**
reformat: esami minor_refactor: main 

esami: modificata la visualizzazione degli esami. Nello specifico, aggiunta separazione tra orario e luogo dell'appello, \n ad ogni appello per migliore visibilità (alle spese della lunghezza in righe del messaggio)

main: specificati solo gli import effettivamente utilizzati da functions

**Secondo e più pericoloso commit**
change: esami, feature, main

GENERALE: modificato il funzionamento del comando /esami.
Non prevede più il passaggio di parametri ma ha un sottomenù tutto suo

esami: modificato il modo in cui viene fatto il fetch dei dati, utilizzando il database con una query che si basa sui dati memorizzati nell'oggetto "context.user_data"

funzioni: aggiunte diverse funzioni per supportare il nuovo menù inline dedicato al comando /esami. L'oggetto "context.user_data" viene rilasciato  all'input di /esami o quando la ricerva va a buon fine

main: aggiunto qualche handler per supportare il comando /esami