### PR TITLE
fix: aggiornati i link degli esami

### DIFF
--- a/data/markdown/esami_link.md
+++ b/data/markdown/esami_link.md
@@ -1,0 +1,5 @@
+*Link agli esami*
+_Informatica triennale (L-31):_ [link](http://web.dmi.unict.it/corsi/l-31/esami)
+_Matematica triennale (L-35):_ [link](http://web.dmi.unict.it/corsi/l-35/esami)
+_Informatica magistrale (LM-18):_ [link](http://web.dmi.unict.it/corsi/lm-18/esami)
+_Matematica magistrale (LM-40):_ [link](http://web.dmi.unict.it/corsi/lm-40/esami)

--- a/data/markdown/lezioni_link.md
+++ b/data/markdown/lezioni_link.md
@@ -1,0 +1,5 @@
+*Link agli orari delle lezioni*
+_Informatica triennale (L-31):_ [link](http://web.dmi.unict.it/corsi/l-31/orario-lezioni)
+_Matematica triennale (L-35):_ [link](http://web.dmi.unict.it/corsi/l-35/orario-lezioni)
+_Informatica magistrale (LM-18):_ [link](http://web.dmi.unict.it/corsi/lm-18/orario-lezioni)
+_Matematica magistrale (LM-40):_ [link](http://web.dmi.unict.it/corsi/lm-40/orario-lezioni)

--- a/functions.py
+++ b/functions.py
@@ -2,7 +2,7 @@
 
 # Telegram
 import telegram
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, Bot
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, Bot, ParseMode
 from telegram.ext import Updater, Filters, MessageHandler, CommandHandler, CallbackQueryHandler, RegexHandler, CallbackContext
 from telegram.error import (TelegramError, Unauthorized, BadRequest, TimedOut, ChatMigrated, NetworkError)
 
@@ -438,10 +438,9 @@ def help(update: Update, context: CallbackContext):
 
     keyboard.append(
         [
-            InlineKeyboardButton("📖 Esami (Triennale)",    url='http://dev7.unict.it/_esami_x_curl.php?cds=X81&aa=1' + str(get_year_code(12 , 20))),
-            InlineKeyboardButton("📖 Esami (Magistrale)",   url='http://dev7.unict.it/_esami_x_curl.php?cds=W82&aa=1' + str(get_year_code(12 , 20))),
+            InlineKeyboardButton("📖 Esami (link)",        callback_data="md_esami_link"),
             InlineKeyboardButton("🗓 Aulario",              url='http://aule.dmi.unict.it/booked/Web/view-schedule.php'),
-            InlineKeyboardButton("Lezioni",                 url='http://web.dmi.unict.it/corsi/l-31/orario-lezioni')
+            InlineKeyboardButton("Orari lezioni (link)",    callback_data="md_lezioni_link")
         ]
     )
 
@@ -695,12 +694,12 @@ def md_handler(update: Update, context: CallbackContext):
 
     message_text = read_md(data)
     check_log(update, context, data, 1)
-
+    
     context.bot.editMessageText(
       text=message_text,
       chat_id=query.message.chat_id,
       message_id=query.message.message_id,
-      parse_mode='Markdown'
+      parse_mode=ParseMode.MARKDOWN
     )
 
 


### PR DESCRIPTION
aggiornati i link degli esami: adesso utilizzando gli appositi buttons dal comando help, il bot manderà come risposta un messaggio contenente i link alla pagina degli esami, sia per informatica che per matematica. Lo stesso trattamento è stato riservato per gli orari delle lezioni [closes #80]