### PR TITLE
add: aggiunto il pulsante "?" al comando /start

### DIFF
--- a/data/markdown/start.md
+++ b/data/markdown/start.md
@@ -1,0 +1,2 @@
+Benvenuto! Questo bot è stato realizzato dagli studenti del Corso di Laurea in Informatica al fine di suppotare gli studenti del DMI!
+Per scoprire cosa puoi fare usa /help o premi il pulsante ❔ Help

--- a/functions.py
+++ b/functions.py
@@ -611,10 +611,9 @@ def get_year_code(month, day):
 
 def start(update: Update, context: CallbackContext):
     reply_keyboard = get_help_keyboard()
+    message_text = read_md("start")
     context.bot.sendMessage(chat_id=update.message.chat_id,
-                            text="Benvenuto! Questo bot è stato realizzato dagli studenti del Corso di Laurea in Informatica"\
-                                  "al fine di suppotare gli studenti del DMI!\n"\
-                                  "Per scoprire cosa puoi fare usa /help o premi il pulsante ❔ Help",
+                            text=message_text,
                             reply_markup=reply_keyboard)
 
 def git(update: Update, context: CallbackContext):

--- a/functions.py
+++ b/functions.py
@@ -38,6 +38,7 @@ from module.scraper_notices import scrape_notices
 from module.gitlab import gitlab_handler
 from module.easter_egg_func import *
 from module.regolamento_didattico import *
+from module.utils.keyboard_utils import get_help_keyboard
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -609,7 +610,12 @@ def get_year_code(month, day):
     return str(year)[-2:]
 
 def start(update: Update, context: CallbackContext):
-    context.bot.sendMessage(chat_id=update.message.chat_id, text="Benvenuto! Questo bot è stato realizzato dagli studenti del Corso di Laurea in Informatica al fine di suppotare gli studenti del DMI! Per scoprire cosa puoi fare usa /help")
+    reply_keyboard = get_help_keyboard()
+    context.bot.sendMessage(chat_id=update.message.chat_id,
+                            text="Benvenuto! Questo bot è stato realizzato dagli studenti del Corso di Laurea in Informatica"\
+                                  "al fine di suppotare gli studenti del DMI!\n"\
+                                  "Per scoprire cosa puoi fare usa /help o premi il pulsante ❔ Help",
+                            reply_markup=reply_keyboard)
 
 def git(update: Update, context: CallbackContext):
     check_log(update, context, "gitlab")

--- a/main.py
+++ b/main.py
@@ -63,6 +63,7 @@ def main():
 
 	dp.add_handler(CommandHandler('aulario', informative_callback))
 	dp.add_handler(CommandHandler('help', help))
+	dp.add_handler(MessageHandler(Filters.regex('❔ Help'), help))
 	dp.add_handler(CommandHandler('contributors', informative_callback))
 
 	dp.add_handler(CommandHandler('rappresentanti', informative_callback))

--- a/module/utils/keyboard_utils.py
+++ b/module/utils/keyboard_utils.py
@@ -1,0 +1,10 @@
+from telegram import KeyboardButton, ReplyKeyboardMarkup
+
+
+def get_help_keyboard() -> ReplyKeyboardMarkup:
+    kb = [
+        [
+            KeyboardButton('❔ Help')
+        ],
+    ]
+    return ReplyKeyboardMarkup(kb, resize_keyboard=True)


### PR DESCRIPTION
Quando viene lanciato il comando start (cosa che viene forzata quando il bot viene avviato per la prima volta) il bot aggiunge il pulsante "? help" nella tastiera dell'utente, che si comporterà esattamente come il comando /help [closes #89]

Per chi ha avviato il bot in precedenza, è necessario lanciare manualmente il comando /start.