### PR TITLE
fix: protect db against SQL injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ This project is made possible thanks to the contributions of:
 - [Ernesto Casablanca](https://github.com/TendTo)
 - [Graziano Di Grande](https://github.com/Drendog)
 - [Santo Cariotti](https://github.com/dcariotti)
+- [Giuseppe Criscione](https://github.com/datalux)

--- a/data/markdown/contributors.md
+++ b/data/markdown/contributors.md
@@ -1,2 +1,2 @@
-@Helias, @adrianoferraguto, @Veenz, @simone989, @TkdAlex, @aegroto, @Squalex95, @LucaCavallaro, @Pierpaolo791, @Wornairz, @herbrant, @RayperZ, @margazz, @BeastHunter19, @D4ed4lUS, @Warcreed, @TendTo, @Adrenoid, @dcariotti
+@Helias, @adrianoferraguto, @Veenz, @simone989, @TkdAlex, @aegroto, @Squalex95, @LucaCavallaro, @Pierpaolo791, @Wornairz, @herbrant, @RayperZ, @margazz, @BeastHunter19, @D4ed4lUS, @Warcreed, @TendTo, @Adrenoid, @dcariotti, @datalux
 https://github.com/UNICT-DMI/Telegram-DMI-Bot.git

--- a/functions.py
+++ b/functions.py
@@ -622,7 +622,7 @@ def git(update: Update, context: CallbackContext):
     else:
         db = sqlite3.connect('data/DMI_DB.db')
 
-        if db.execute("SELECT Chat_id FROM 'Chat_id_List' WHERE Chat_id = %s" % chat_id).fetchone():
+        if db.execute("SELECT Chat_id FROM 'Chat_id_List' WHERE Chat_id = ?",  chat_id).fetchone():
             gitlab_handler(update, context)
         else:
             context.bot.sendMessage(chat_id=chat_id, text="🔒 Non hai i permessi per utilizzare la funzione %s\nUtilizzare il comando /request <nome> <cognome> <e-mail> (il nome e il cognome devono essere scritti uniti Es: Di Mauro -> DiMauro)" % executed_command)
@@ -644,8 +644,8 @@ def report(update: Update, context: CallbackContext):
         if  context.args:
             db = sqlite3.connect('data/DMI_DB.db')
             message = "⚠️Segnalazione⚠️\n"
-            if db.execute("SELECT Chat_id FROM 'Chat_id_List' WHERE Chat_id = %s" %chat_id).fetchone():
-                name = db.execute("SELECT Username,Nome,Cognome FROM 'Chat_id_List' WHERE Chat_id = %s" %chat_id)
+            if db.execute("SELECT Chat_id FROM 'Chat_id_List' WHERE Chat_id = ?", chat_id).fetchone():
+                name = db.execute("SELECT Username,Nome,Cognome FROM 'Chat_id_List' WHERE Chat_id = ?", chat_id)
                 row = name.fetchone()
 
                 if row[0] is None:

--- a/functions.py
+++ b/functions.py
@@ -192,7 +192,7 @@ def callback(update: Update, context: CallbackContext):
 
         try:
             if len(array_value) == 5:
-                conn.execute("INSERT INTO 'Chat_id_List' VALUES ("+update.callback_query.data+",'" + array_value[4] + "','" + array_value[1] + "','" + array_value[2] + "','" + array_value[3] + "') ")
+                conn.execute("INSERT INTO 'Chat_id_List' VALUES (?, ?, ?, ?, ?)", update.callback_query.data, array_value[4], array_value[1], array_value[2], array_value[3])
                 context.bot.sendMessage(chat_id=update.callback_query.data, text="🔓 La tua richiesta è stata accettata. Leggi il file README")
                 context.bot.sendDocument(chat_id=update.callback_query.data, document=open('data/README.pdf', 'rb'))
 
@@ -201,7 +201,7 @@ def callback(update: Update, context: CallbackContext):
 
                 context.bot.sendMessage(chat_id=config_map['dev_group_chatid'], text=str(array_value[1]) + " " + str(array_value[2] + str(" è stato inserito nel database")))
             elif len(array_value) == 4:
-                conn.execute("INSERT INTO 'Chat_id_List'('Chat_id','Nome','Cognome','Email') VALUES (" + update.callback_query.data + ",'" + array_value[1] + "','" + array_value[2] + "','" + array_value[3] + "')")
+                conn.execute("INSERT INTO 'Chat_id_List'('Chat_id','Nome','Cognome','Email') VALUES (?, ?, ?, ?)", update.callback_query.data, array_value[1], array_value[2], array_value[3])
                 context.bot.sendMessage(chat_id=update.callback_query.data, text="🔓 La tua richiesta è stata accettata. Leggi il file README")
                 context.bot.sendDocument(chat_id=update.callback_query.data, document=open('data/README.pdf', 'rb'))
 
@@ -330,7 +330,7 @@ def request(update: Update, context: CallbackContext):
 
     if chat_id > 0:
         # if we do not find any chat_id in the db
-        if not conn.execute("SELECT Chat_id FROM Chat_id_List WHERE Chat_id = " + str(chat_id)).fetchone():
+        if not conn.execute("SELECT Chat_id FROM Chat_id_List WHERE Chat_id = ?", str(chat_id)).fetchone():
             message_text = "✉️ Richiesta inviata"
             keyboard = [[]]
 
@@ -364,12 +364,12 @@ def add_db(update: Update, context: CallbackContext):
         # /add nome cognome e-mail username chatid
         array_value = update.message.text.split(" ")
         if len(array_value) == 6:
-            conn.execute("INSERT INTO 'Chat_id_List' VALUES (" + array_value[5] + ",'" + array_value[4] + "','" + array_value[1] + "','" + array_value[2] + "','" + array_value[3] + "') ")
+            conn.execute("INSERT INTO 'Chat_id_List' VALUES (?, ?, ?, ?, ?)", array_value[5], array_value[4], array_value[1], array_value[2], array_value[3])
             context.bot.sendMessage(chat_id=array_value[5], text="🔓 La tua richiesta è stata accettata. Leggi il file README")
             context.bot.sendDocument(chat_id=array_value[5], document=open('data/README.pdf', 'rb'))
             conn.commit()
         elif len(array_value) == 5:
-            conn.execute("INSERT INTO 'Chat_id_List'('Chat_id','Nome','Cognome','Email') VALUES (" + array_value[4] + ",'" + array_value[1] + "','" + array_value[2] + "','" + array_value[3] + "')")
+            conn.execute("INSERT INTO 'Chat_id_List'('Chat_id','Nome','Cognome','Email') VALUES (?, ?, ?, ?)", array_value[4], array_value[1], array_value[2], array_value[3])
             context.bot.sendMessage(chat_id=int(array_value[4]), text="🔓 La tua richiesta è stata accettata. Leggi il file README")
             context.bot.sendDocument(chat_id=int(array_value[4]), document=open('data/README.pdf', 'rb'))
             conn.commit()
@@ -392,7 +392,7 @@ def drive(update: Update, context: CallbackContext):
     if chat_id < 0:
         context.bot.sendMessage(chat_id=chat_id, text="La funzione /drive non è ammessa nei gruppi")
     else:
-        if conn.execute("SELECT Chat_id FROM 'Chat_id_List' WHERE Chat_id = " + str(chat_id)).fetchone():
+        if conn.execute("SELECT Chat_id FROM 'Chat_id_List' WHERE Chat_id = ?", str(chat_id)).fetchone():
             keyboard2 = [[]]
 
             try:

--- a/module/gitlab.py
+++ b/module/gitlab.py
@@ -356,13 +356,13 @@ def gitlab_handler(update: Update, context: CallbackContext):
 
             db_result = db.execute(query % (origin_id, blob_id)).fetchone()
         else:
-            db_result = db.execute("SELECT parent_id, name FROM gitlab WHERE id = %s" % origin_id).fetchone()
+            db_result = db.execute("SELECT parent_id, name FROM gitlab WHERE id = ?", origin_id).fetchone()
 
         if db_result:
             parent = db_result
 
         if action == 'x':
-            _type = db.execute('SELECT type FROM gitlab WHERE id = %s' % origin_id).fetchone()
+            _type = db.execute('SELECT type FROM gitlab WHERE id = ?', origin_id).fetchone()
             action = (_type[0] if _type else 'subgroup')[0]
 
         if action == 's':
@@ -381,7 +381,7 @@ def gitlab_handler(update: Update, context: CallbackContext):
         elif action == 'p':
             buttons.extend(explore_repository_tree(origin_id, '/', db))
         elif action == 't':
-            path = db.execute("SELECT pathname FROM gitlab WHERE id = '%s'" % blob_id).fetchone()
+            path = db.execute("SELECT pathname FROM gitlab WHERE id = ?", blob_id).fetchone()
             buttons.extend(explore_repository_tree(origin_id, path, db))
         elif action == 'b':
             blob = {

--- a/module/professori.py
+++ b/module/professori.py
@@ -31,7 +31,7 @@ def prof_cmd(profs):
 
         professors = []
         for i in profs:
-            rows = conn.execute("SELECT * FROM professors WHERE Nome LIKE '%" + i + "%' OR Cognome LIKE '%" + i + "%' ").fetchall()
+            rows = conn.execute("SELECT * FROM professors WHERE Nome LIKE ? OR Cognome LIKE ?",  ('%' + i + '%'), ('%' + i + '%')).fetchall()
             professors += rows
 
         for prof in professors:

--- a/module/scraper_exams.py
+++ b/module/scraper_exams.py
@@ -88,13 +88,12 @@ def scrape_exams(year_exams, delete= False):
 		values += '("'+'", "'.join(str(v).replace("\"", "'") for v in i.values())+'"),' #serve ad evitare errori nella formazione della query, che nascono dalla presenza di " nel bel mezzo di un valore
 	values = values[:-1]
 
-	query = "INSERT INTO exams ({}) VALUES {}".format(columns, values)
 
 	conn = sqlite3.connect('data/DMI_DB.db')
 	if(delete):
 		conn.execute('DELETE FROM `exams`;') # TRUNCATE professors
 	try:
-		conn.execute(query)
+		conn.execute("INSERT INTO exams (?) VALUES ?", columns, values)
 		conn.commit()
 	except:
 		logger.error("The exams query could not be executed")

--- a/module/scraper_lessons.py
+++ b/module/scraper_lessons.py
@@ -77,11 +77,9 @@ def scrape_lessons(year_exams):
     	values += '("'+'", "'.join(str(v) for v in i.values())+'"),'
     values = values[:-1]
 
-    query = "INSERT INTO lessons ({}) VALUES {}".format(columns, values)
-
     conn = sqlite3.connect('data/DMI_DB.db')
     conn.execute('DELETE FROM `lessons`;') # TRUNCATE lessons
-    conn.execute(query)
+    conn.execute("INSERT INTO lessons (?) VALUES ?", columns, values)
     conn.commit()
     conn.close()
 

--- a/module/scraper_professors.py
+++ b/module/scraper_professors.py
@@ -93,11 +93,10 @@ def scrape_prof():
     	values += '("'+'", "'.join(str(v).replace('"', '') for v in i.values())+'"),'
     values = values[:-1]
 
-    query = "INSERT INTO professors ({}) VALUES {}".format(columns, values)
 
     conn = sqlite3.connect('data/DMI_DB.db')
     conn.execute('DELETE FROM `professors`;') # TRUNCATE professors
-    conn.execute(query)
+    conn.execute("INSERT INTO professors (?) VALUES ?", columns, values)
     conn.commit()
     conn.close()
 

--- a/module/shared.py
+++ b/module/shared.py
@@ -24,7 +24,7 @@ def check_log(update: Update, context: CallbackContext, type, callback=0):
     if (config_map['debug']['disable_db'] == 0):
         today = str(date.today())
         conn = sqlite3.connect('data/DMI_DB.db')
-        conn.execute("INSERT INTO stat_list VALUES ('"+ str(type) + "',"+str(chat_id)+",'"+str(today)+" ')")
+        conn.execute("INSERT INTO stat_list VALUES (?, ?, ?)", str(type), str(chat_id), str(today))
         conn.commit()
         conn.close()
 


### PR DESCRIPTION
According to the sqlite3 [doc](https://docs.python.org/3/library/sqlite3.html):
"You shouldn’t assemble your query using Python’s string operations because doing so is insecure. [...] Instead, use the DB-API’s parameter substitution".