### PR TITLE
Avoid job updater problems setting python-telegram-bot version to 12.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want to test the bot by creating your personal instance, follow this step
 
 #### To install with *pip3*
 
-- python-telegram-bot
+- python-telegram-bot==12.8
 - pydrive
 - requests
 - beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot
+python-telegram-bot==12.8
 pydrive
 requests
 beautifulsoup4


### PR DESCRIPTION
As already discussed, [python-telegram-bot v13.0](https://github.com/python-telegram-bot/python-telegram-bot/releases/tag/v13.0) introduces changes on Job Queue. 
As a result, scrapers may not work as expected. 