### PR TITLE
Getting rid of dryscrape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,20 @@
-FROM  ubuntu:18.04
+FROM python:3.8.5-slim-buster
 
 ARG TOKEN
-ENV DMI_BOT_REPO    https://github.com/UNICT-DMI/Telegram-DMI-Bot.git
-ENV DMI_BOT_DIR    /usr/local
+
+WORKDIR /dmibot
 
 RUN apt-get update && \
-  apt-get install -y \
-	git \
-	git-lfs \
-	python3 \
-	python3-pip\
-	language-pack-it
+	apt-get install -y
 
-RUN mkdir -p $DMI_BOT_DIR && \
-  cd $DMI_BOT_DIR && \
-  git clone -b master $DMI_BOT_REPO dmibot
+COPY requirements.txt .
+#Install requirements
+RUN pip3 install -r requirements.txt
 
-RUN pip3 install -r $DMI_BOT_DIR/dmibot/requirements.txt
+COPY . .
+#Final setup settings and databases
+RUN mv data/DMI_DB.db.dist data/DMI_DB.db &&\
+	mv config/settings.yaml.dist config/settings.yaml &&\
+	python3 setup.py ${TOKEN}
 
-RUN cp $DMI_BOT_DIR/dmibot/data/DMI_DB.db.dist $DMI_BOT_DIR/dmibot/data/DMI_DB.db
-RUN cp $DMI_BOT_DIR/dmibot/config/settings.yaml.dist $DMI_BOT_DIR/dmibot/config/settings.yaml
-RUN echo $TOKEN > $DMI_BOT_DIR/dmibot/config/token.conf
+CMD ["python3", "main.py"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Telegram-DMI-Bot** is the platform that powers **@DMI_bot**, a Telegram bot aided at helping students find informations about professors, classes' schedules, administration's office hours and more.
 
 ### Using the live version
+
 The bot is live on Telegram with the username [@DMI_Bot](https://telegram.me/DMI_Bot).
 Send **'/start'** to start it, **'/help'** to see a list of commands.
 
@@ -11,21 +12,32 @@ Please note that the commands and their answers are in Italian.
 ---
 
 ### Setting up a local instance
+
+#### Automatically
+
+- Follow the [**Docker container**](##Docker-container) section
+
+#### Manually
+
 If you want to test the bot by creating your personal instance, follow this steps:
-* **Clone this repository** or download it as zip.
-* **Send a message to your bot** on Telegram, even '/start' will do. If you don't, you could get an error
-* Make a copy of the file "data/DMI_DB.db.dist" in the same directory and rename it to "DMI_DB.db" to enable the database sqlite
-* Make a copy of the file "config/settings.yaml.dist" in the same directory and rename it to "settings.yaml" (If you don't have a token, message Telegram's [@BotFather](http://telegram.me/Botfather) to create a bot and get a token for it)
-* Now you can launch "main.py" with your Python3 interpreter
+
+- **Install [system requirements](#System-requirements)**
+- **Clone this repository** or download it as zip.
+- **Send a message to your bot** on Telegram, even '/start' will do. If you don't, you could get an error
+- **Make a copy** of the file `data/DMI_DB.db.dist` in the same directory and rename it to `DMI_DB.db` to enable the database sqlite
+- **Make a copy** of the file `config/settings.yaml.dist` in the same directory and rename it to `settings.yaml`
+- **Set your token** with `python3 setup.py <token>` or edit `settings.yaml` manually
+- **Launch** the bot with `python3 main.py`
+
+_(If you don't have a token, message Telegram's [@BotFather](http://telegram.me/Botfather) to create a bot and get a token for it)_
 
 ### System requirements
 
 - Python 3
 - python-pip3
 - language-pack-it
-- libqtwebkit (v5)
 
-#### To install with *pip3*
+#### To install with _pip3_
 
 - python-telegram-bot==12.8
 - pydrive
@@ -33,78 +45,55 @@ If you want to test the bot by creating your personal instance, follow this step
 - beautifulsoup4
 - python-gitlab
 - pytz
+- matplotlib
 - pandas
-- dryscrape
 - pillow
+- lxml
 
 To install all the requirements you can run:
+
 ```bash
-sudo apt install libqtwebkit-dev
 pip3 install -r requirements.txt
 ```
 
-### Known problems on Ubuntu 20.04:
+### Docker container
 
-* #### **Installing libqtwebkit**
+#### How to use
 
-Open terminal in your repo folder and run command: 
+Build the image _dmibot_ with docker:
 
-```bash 
-sudo add-apt-repository ppa:rock-core/qt4
+```
+$ docker build ./ -t dmibot --build-arg TOKEN=<token_API>
 ```
 
-After adding the PPA, it should automatically refresh the system package cache. If not, you may run command to manually update the package cache:
+_(If you don't have a token, message Telegram's [@BotFather](http://telegram.me/Botfather) to create a bot and get a token for it)_
 
-```bash
-sudo apt update
+Run the container _dmibot_:
+
 ```
-  
-  
-  
-* #### **Installing dryscrape**
-
-Download webkit-server from github:
-
-```bash
-git clone https://github.com/niklasb/webkit-server.git webkit-server
+$ docker run -it dmibot
 ```
 
-Change in webkit-server/setup.py :
+The container **automatically** start the bot with:
 
-```python
-shutil.copy('src/webkit_server', self.build_purelib)
-shutil.copy('src/webkit_server', self.build_platlib)
+```
+$ cd /usr/local/dmibot && python3 main.py
 ```
 
-to
-
-```python
-shutil.copy('src/webkit_server.pro', self.build_purelib)
-shutil.copy('src/webkit_server.pro', self.build_platlib)
-```
-
-then run:
-
-```bash
-cd webkit-server
-python setup.py install
-```
-
-- [x] There you go!
-
-
-
+---
 
 ### Special functions
 
 Notes: only some users are allowed to use these commands indeed there is an if condition that check the chatid of the user that can use them
 
 #### - /stats
+
 You can enable these commands setting **disable_db = 0** and copy **data/DMI_DB.db.dist** into **data/DMI_DB.db**
 
 This command shows the statistics of the times where the commands are used in the last 30 days.
 
 #### - /drive /request /adddb
+
 You can enable these commands setting **disable_drive = 0**, configure the GoogleDrive credentials and copy **data/DMI_DB.db.dist** into **data/DMI_DB.db**.
 
 **/drive**: command to get the GoogleDrive files
@@ -112,55 +101,37 @@ You can enable these commands setting **disable_drive = 0**, configure the Googl
 **/adddb** allows some special users to give the access to /drive to another user
 
 ##### **Configure Drive**
+
 - open a project on the Google Console Developer
 - enable Drive API
 - download the drive_credentials.json and put it on config/
 - copy **config/settings.yaml.dist** into **config/settings.yaml**, then configure it
 
-### Docker container
-
-#### How to use
-Build image dmibot with docker:
-
-```
-$ docker build ./ -t dmibot --build-arg TOKEN=<token_API>
-```
-
-Run the container dmibot:
-
-```
-$ docker run -it dmibot
-```
-
-Now you can go to the dmibot directory and run the bot:
-
-```
-$ cd /usr/local/dmibot/
-$ python main.py
-```
-
-Note: if you need to run the main.py in a VPS, you will need now xvfb-run to run it (`xvfb-run python3 main.py`), because **dryscrape** requires it.
+---
 
 ### Testing
 
-#### To install with *pip3*
+#### To install with _pip3_
 
 - pytest
 - pytest-asyncio
 - telethon
 
 To install all the test requirements you can run:
+
 ```bash
 pip3 install -r test-requirements.txt
 ```
 
 Steps:
+
 - Sign in your Telegram account with your phone number **[here](https://my.telegram.org/auth)**. Then choose “API development tools”
 - If it is your first time doing so, it will ask you for an app name and a short name, you can change both of them later if you need to. Submit the form when you have completed it
 - You will then see the api_id and api_hash for your app. These are unique to your app, and not revocable.
 - Edit the folling values in the config/settings.yaml file:
+
 ```yaml
-test: 
+test:
   api_hash: hash of the telegram app used for testing
   api_id: id of the telegram app used for testing
   session: session of the telegram app used for testing (see steps below)
@@ -169,23 +140,29 @@ test:
   representatives_group: representatives' group id used for testing
   dev_group_chatid: dev's group id used for testing
 ```
-- Copy the file "tests/conftest.py" in the root folder and Run 
+
+- Copy the file "tests/conftest.py" in the root folder and Run
+
 ```bash
 python3 conftest.py .
 ```
-- Follow the procedure and copy the session value it provides in the settings file in "test:session". You can then delete the "conftest.py" you just used, you won't need it again
+
+- Follow the procedure and copy the session value it provides in the settings file in "test:session". You can then delete the `conftest.py` you just used, you won't need it again
 - Edit the remaining values in the settings file as you like
 
 **Check [here](https://dev.to/blueset/how-to-write-integration-tests-for-a-telegram-bot-4c0e) if you want to have more information on the steps above**
 
 Start tests:
+
 ```bash
 pytest
 ```
 
 ### License
+
 This open-source software is published under the GNU General Public License (GNU GPL) version 3. Please refer to the "LICENSE" file of this project for the full text.
 
 ### Contributors
+
 You can find the list of contributors [here](CONTRIBUTORS.md)
 If you want to contribute, make sure to read the [guidelines](CONTRIBUTING.md)

--- a/module/aulario.py
+++ b/module/aulario.py
@@ -6,7 +6,7 @@ from module.shared import read_md
 
 from datetime import date, datetime
 import json
-import dryscrape
+import requests
 import time
 import pandas as pd
 import calendar
@@ -15,13 +15,14 @@ from io import BytesIO
 
 BACK_BUTTON_TEXT =  "Indietro ❌"
 
-def updater_schedule(context):
-    session = dryscrape.Session()
-    aulario_url = read_md("aulario")
-    session.visit(aulario_url)
-    time.sleep(0.5)
+import logging
 
-    response = session.body()
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def updater_schedule(context):
+    response = requests.get(read_md("aulario")).text
+    time.sleep(0.5)
 
     tables = pd.read_html(response)
     days = {}
@@ -46,6 +47,8 @@ def updater_schedule(context):
 
     with open("data/json/subjs.json", "w+") as outfile:
         json.dump(days, outfile)
+
+    logger.info("Aulario loaded.")
 
 
 def get_json(file):

--- a/module/job_updater.py
+++ b/module/job_updater.py
@@ -1,10 +1,28 @@
+import re
+import sqlite3
 from telegram.ext import CallbackContext
 from module.shared import check_print_old_exams, get_year_code
 from module.scraper_professors import scrape_prof
 from module.scraper_lessons import scrape_lessons
 from module.scraper_exams import scrape_exams
 
+
+def initialize_database():
+    """Makes sure the database is initialized correctly.
+    Executes all the queries located in the data/DMI_DB.sql file
+    """
+    with open("data/DMI_DB.sql", "r") as f:
+        queries = re.split(pattern=r"(?<=\);)\s", string=f.read())
+        conn = sqlite3.connect('data/DMI_DB.db')
+        for query in queries:
+            conn.execute(query)
+        conn.commit()
+        conn.close()
+
+
 def updater_lep(context: CallbackContext) -> None:
+    initialize_database()
+
     year_exam = get_year_code(11 , 30)               # aaaa/12/01 (cambio nuovo anno esami) data dal quale esami del vecchio a nuovo anno coesistono
 
     scrape_exams("1" + str(year_exam), delete= True) # flag che permette di eliminare tutti gli esami presenti in tabella exams

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ python-gitlab
 pytz
 matplotlib
 pandas
-dryscrape
 pillow
+lxml

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+"""Used to set secret variables, like the token, when using the Dockerfile"""
+import sys
+import argparse
+import yaml
+
+
+def create_argparser() -> argparse.ArgumentParser:
+    """Generates the appropriate argparser
+
+    Returns:
+        :class:`argparse.ArgumentParser`: the argparser used to parse the arguments
+    """
+    parser = argparse.ArgumentParser(description="Settings utility to edit the config/settings.yaml file", allow_abbrev=True)
+    parser.add_argument('token', help="the token of your telegram bot")
+    parser.add_argument('--test_api_hash', help="hash of the telegram app used for testing")
+    parser.add_argument('--test_api_id', type=int, help="id of the telegram app used for testing")
+    parser.add_argument('--test_session', help="session of the telegram app used for testing")
+    parser.add_argument('--test_tag', help="tag of the telegram bot used for testing. Include the '@' character")
+    parser.add_argument('--test_token', help="token for the telegram bot used for testing")
+    parser.add_argument('-p', '--path', help="path of the setting file (default: %(default)s)", default="config/settings.yaml")
+    return parser
+
+
+def main():
+    """Main function"""
+    parser = create_argparser()
+    args = vars(parser.parse_args())
+
+    try:
+        with open(args['path'], "r") as yaml_file:
+            config_map = yaml.safe_load(yaml_file)
+    except FileNotFoundError as e:
+        print(e)
+        sys.exit(2)
+
+    config_map['token'] = args['token']
+    config_map['test']['api_id'] = args['test_api_id']
+    config_map['test']['api_hash'] = args['test_api_hash']
+    config_map['test']['session'] = args['test_session']
+    config_map['test']['tag'] = args['test_tag']
+    config_map['test']['token'] = args['test_token']
+
+    with open(args['path'], "w") as yaml_file:
+        yaml.dump(config_map, yaml_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I had many issue tiring to install the dryscrape dependency, even on a Docker container, so after some investigation, i concluded it can be replaced entirely with a simple requests.get(). [ closes #131 ]

Some other changes include
- a simpler version of the Dockerfile
- a small script used to set the secret settings in the _settings.yaml_ file in the Docker image
- an initialization function that makes sure the database contains the needed tables
