### PR TITLE
Fix "Regolamento didattico" button handler on "Help menu"

### DIFF
--- a/module/commands/help.py
+++ b/module/commands/help.py
@@ -32,7 +32,7 @@ def help_cmd(update: Update, context: CallbackContext):
     ])
 
     keyboard.append([
-        InlineKeyboardButton("Regolamento Didattico", callback_data="regolamentodidattico_button")
+        InlineKeyboardButton("Regolamento Didattico", callback_data="reg_button_home")
     ])
 
     keyboard.append([


### PR DESCRIPTION
As you can read in this line [1] the callback used for "Regolamento didattico"
is not in the list defined in these lines [2].
This is because the pattern `r'^reg_button_.*'` is not good if
callback_data is `regolamentodidattico_button`. So, we could rewrite the
pattern as `r'^reg(olamentodidattico)?_button(_.*)?'` but it's just something
extra 'cause we already use the callback `reg_button_home` to go back [3].

[1] https://github.com/UNICT-DMI/Telegram-DMI-Bot/blob/d8e79ec78f/module/commands/help.py#L35
[2] https://github.com/UNICT-DMI/Telegram-DMI-Bot/blob/d8e79ec78f/main.py#L136-L139
[3] https://github.com/UNICT-DMI/Telegram-DMI-Bot/blob/d8e79ec78f/module/commands/regolamento_didattico.py#L127

Resolves #163 