### PR TITLE
Fix professors' Markdown parsing

### DIFF
--- a/module/commands/professori.py
+++ b/module/commands/professori.py
@@ -17,10 +17,21 @@ def prof(update: Update, context: CallbackContext):
     """
     check_log(update, "prof")
     message_text = generate_prof_text(context.args)
-    if len(message_text) > 4096:
-        send_message(update, context, message_text)
-    else:
-        context.bot.sendMessage(chat_id=update.message.chat_id, text=message_text, parse_mode='Markdown')
+
+    message_text_list = message_text.split('\n\n')
+    professors, total_profs = message_text_list[:-1], message_text_list[-1]
+
+    # 15 professors are like ~3500 characters
+    for index in range(0, len(professors), 15):
+        message_text = '\n\n'.join(professors[index:index+15])
+        # if this is the last message, we could append the "Total results"
+        if len(professors) <= index+15:
+            message_text += '\n\n'+total_profs
+
+        context.bot.sendMessage(chat_id=update.message.chat_id,
+                text=message_text,
+                parse_mode='MarkdownV2',
+                disable_web_page_preview=True)
 
 
 def generate_prof_text(names: list) -> str:

--- a/module/data/professor.py
+++ b/module/data/professor.py
@@ -6,9 +6,16 @@ import bs4
 import requests
 from module.data.db_manager import DbManager
 from module.data.scrapable import Scrapable
+from telegram.utils.helpers import escape_markdown
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+def em(text):
+    """
+    Alias for `escape_markdown` function
+    """
+    return escape_markdown(text, version=2)
 
 
 class Professor(Scrapable):
@@ -153,18 +160,18 @@ class Professor(Scrapable):
         return f"Professor: {self.__dict__}"
 
     def __str__(self):
-        string = f"*Ruolo:* {self.ruolo}\n"\
-                f"*Nome:* {self.nome}\n"
+        string = f"*Ruolo:* {em(self.ruolo)}\n"\
+                f"*Nome:* {em(self.nome)}\n"
         if self.email:
-            string += f"*Indirizzo email:* {self.email}\n"
+            string += f"*Indirizzo email:* {em(self.email)}\n"
         if self.scheda_dmi:
-            string += f"*Scheda DMI:* {self.scheda_dmi}\n"
+            string += f"*Scheda DMI:* {em(self.scheda_dmi)}\n"
         if self.sito:
-            string += f"*Sito web:* {self.sito}\n"
+            string += f"*Sito web:* {em(self.sito)}\n"
         if self.ufficio:
-            string += f"*Ufficio:* {self.ufficio}\n"
+            string += f"*Ufficio:* {em(self.ufficio)}\n"
         if self.telefono:
-            string += f"*Telefono:* {self.telefono}\n"
+            string += f"*Telefono:* {em(self.telefono)}\n"
         if self.fax:
-            string += f"*Fax:* {self.fax}\n"
+            string += f"*Fax:* {em(self.fax)}\n"
         return string


### PR DESCRIPTION
Escaping the professors text in Markdown V1 raised errors when you tried
to search a large numbers of professors (like `/prof G` = 33 entries).
This commit introduces the Markdown V2[1] escaping mode and the
grouping of professors for 15 entries.
    
It also disables the web page preview!
    
[1] https://python-telegram-bot.readthedocs.io/en/stable/telegram.parsemode.html#telegram.ParseMode.MARKDOWN_V2
