### PR TITLE
Fix when `/prof` returns 0 elements

### DIFF
--- a/module/commands/professori.py
+++ b/module/commands/professori.py
@@ -21,6 +21,11 @@ def prof(update: Update, context: CallbackContext):
     message_text_list = message_text.split('\n\n')
     professors, total_profs = message_text_list[:-1], message_text_list[-1]
 
+    if len(professors) == 0:
+        context.bot.sendMessage(chat_id=update.message.chat_id,
+                text=message_text)
+        return
+
     # 15 professors are like ~3500 characters
     for index in range(0, len(professors), 15):
         message_text = '\n\n'.join(professors[index:index+15])

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -227,7 +227,14 @@ async def test_prof_cmd(client: TelegramClient):
     """
     conv: Conversation
     async with client.conversation(bot_tag, timeout=TIMEOUT) as conv:
-        commands = ("/prof", "/prof bilotta", "/prof giuseppe bilotta", "/prof rocco senteta")
+        commands = (
+            "/prof",
+            "/prof bilotta",
+            "/prof giuseppe bilotta",
+            "/prof rocco senteta",
+            "/prof Dario",
+            "/prof a",
+        )
 
         for command in commands:
             await conv.send_message(command)  # send a command


### PR DESCRIPTION
AFFECTED AREA:
    `/prof` command

ROOT CAUSE:
    `professors` array empty not handled

FIX:
    Check first if `professors` array is empty. In that case, send the
    error message and return