### PR TITLE
Handle lessons table exception 

### DIFF
--- a/module/data/lesson.py
+++ b/module/data/lesson.py
@@ -77,6 +77,11 @@ class Lesson(Scrapable):
                     semestre = 1
 
                 table = soup.find('table', id='tbl_small_font')
+
+                if not table:
+                    logger.warning("Lessons table not found.")
+                    break
+
                 tr_all = table.find_all('tr')
 
                 anno = 1

--- a/module/data/lesson.py
+++ b/module/data/lesson.py
@@ -79,7 +79,7 @@ class Lesson(Scrapable):
                 table = soup.find('table', id='tbl_small_font')
 
                 if not table:
-                    logger.warning("Lessons table not found.")
+                    logger.warning(f"Lessons table for `{url}` not found.")
                     break
 
                 tr_all = table.find_all('tr')


### PR DESCRIPTION
This error occurs when [1] does not have a valid table to scrape and
save.

Fixes https://github.com/UNICT-DMI/Telegram-DMI-Bot/issues/227

[1]: http://web.dmi.unict.it/corsi/l-31/orario-lezioni