### PR TITLE
feat: add a command that display a 3D map of DMI

### DIFF
--- a/data/markdown/dmi_3d.md
+++ b/data/markdown/dmi_3d.md
@@ -1,0 +1,1 @@
+https://my.matterport.com/show/?m=g9ZenVgF96z&fbclid=IwAR1DIb\_4hMC0gUbUf4uFd0ORbJ7gqRg7o0StwNUa17MKp71u6VDp809WhO4

--- a/main.py
+++ b/main.py
@@ -63,6 +63,7 @@ def add_commands(up: Updater) -> None:
         BotCommand("regolamentodidattico", "lista dei regolamenti didattici"),
         BotCommand("ricevimenti", "lista orari ricevimenti dei professori"),
         BotCommand("trasporto_urbano_unict", "link orari BRTU"),
+        BotCommand("dmi_3d", "mappa in 3D del DMI"),
     ]
     up.bot.set_my_commands(commands=commands)
 
@@ -97,6 +98,7 @@ def add_handlers(dp: Dispatcher) -> None:
     dp.add_handler(CommandHandler('cus', informative_callback))
     dp.add_handler(CommandHandler('ricevimenti', informative_callback))
     dp.add_handler(CommandHandler('trasporto_urbano_unict', informative_callback))
+    dp.add_handler(CommandHandler('dmi_3d', informative_callback))
 
     dp.add_handler(CommandHandler('lezioni', lezioni))
     dp.add_handler(CommandHandler('esami', esami))


### PR DESCRIPTION
Come richiesto nella #232, ho aggiunto un comando che mostra il link alla mappa del dmi in 3D.

closes https://github.com/UNICT-DMI/Telegram-DMI-Bot/issues/232