### PR TITLE
Update rappresentanti_informatica.md

### DIFF
--- a/data/markdown/rappresentanti_informatica.md
+++ b/data/markdown/rappresentanti_informatica.md
@@ -1,2 +1,2 @@
-Triennale:Cambria Nicolò|Cipria Fabrizio - @FabrizioCipria|D'Anna Kamil - @Heavenly0000|Gigliuto Emily - @imemgi|La Rocca Lorenzo - @lorelarocca|Lo Castro Giuseppe - @shownunderlight|Mirabella Leonardo - @infra\_blue|Russo Mirko - @altair\_mr|Spina Simone - @simonze0|Vaccaro Giuseppe - @VaccSpacc
+Triennale:Cipria Fabrizio - @FabrizioCipria|D'Anna Kamil - @Heavenly0000|Gigliuto Emily - @imemgi|La Rocca Lorenzo - @lorelarocca|Lo Castro Giuseppe - @shownunderlight|Mirabella Leonardo - @infra\_blue|Russo Mirko - @altair\_mr|Spina Simone - @simonze0|Vaccaro Giuseppe - @VaccSpacc
 Magistrale:Cigna Gaia - @GaiaCigna|Salemi Andrea Filippo - @AndreaNinetyFive


### PR DESCRIPTION
Eliminato il nominativo di Cambria Nicolò perchè non risulta ufficialmente Rappresentante degli Studenti al Corso di Laurea in Informatica Triennale.